### PR TITLE
Handle default arguments in methods

### DIFF
--- a/pyteamcity.py
+++ b/pyteamcity.py
@@ -29,13 +29,18 @@ def get_default_kwargs(func):
 def GET(url_pattern):
     def wrapped_func(f):
         def get_url(*args, **kwargs):
+            # kwargs with default values declared by function
+            all_kwargs = dict(get_default_kwargs(f))
+
+            # kwargs for positional arguments passed by caller
             groups = re.findall('{(\w+)}', url_pattern)
-            for arg, group in zip(args, groups):
-                kwargs[group] = arg
-            for arg, default in get_default_kwargs(f):
-                if arg not in kwargs:
-                    kwargs[arg] = default
-            return _build_url(url_pattern.format(*args, **kwargs), **kwargs)
+            all_kwargs.update(dict(zip(groups, args)))
+
+            # kwargs for keyword arguments passed by caller
+            all_kwargs.update(kwargs)
+
+            return _build_url(url_pattern.format(*args, **all_kwargs),
+                              **all_kwargs)
 
         def inner_func(self, *args, **kwargs):
             kwargs['base_url'] = self.base_url

--- a/test_pyteamcity.py
+++ b/test_pyteamcity.py
@@ -127,6 +127,17 @@ def test_get_all_plugins():
 
 def test_get_all_builds():
     expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+                    'builds/?start=0&count=100')
+    url = tc.get_all_builds(return_type='url')
+    assert url == expected_url
+
+    req = tc.get_all_builds(return_type='request')
+    assert req.method == 'GET'
+    assert req.url == expected_url
+
+
+def test_get_all_builds_with_start_and_count():
+    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
                     'builds/?start=0&count=3')
     url = tc.get_all_builds(start=0, count=3, return_type='url')
     assert url == expected_url


### PR DESCRIPTION
Make method default arguments work

E.g.: if you could `get_all_builds` without providing `start` and `count`, this should work because `get_all_builds` declares these as keyword args with default values.

Cc: @aconrad, @sudarkoff 