### PR TITLE
Add `get_builds`: filter by `build_type` or `branch`

### DIFF
--- a/pyteamcity.py
+++ b/pyteamcity.py
@@ -105,8 +105,22 @@ class TeamCity:
         the Client.
         """
 
-    @GET('builds/?start={start}&count={count}')
-    def get_all_builds(self, start=0, count=100):
+    def get_builds(self, build_type_id='', branch='',
+                   start=0, count=100, **kwargs):
+        if build_type_id:
+            return self.get_all_builds_by_build_type_id(
+                build_type_id, branch,
+                start, count,
+                **kwargs)
+        else:
+            return self.get_all_builds(
+                branch,
+                start, count,
+                **kwargs)
+
+    @GET('builds/?locator=branch:{branch}&start={start}&count={count}')
+    def get_all_builds(self, branch='',
+                       start=0, count=100):
         """
         Gets all builds in the TeamCity server pointed to by this instance of
         the Client.
@@ -117,8 +131,10 @@ class TeamCity:
         :param count: how many builds to return
         """
 
-    @GET('buildTypes/id:{build_type_id}/builds/?start={start}&count={count}')
-    def get_all_builds_by_build_type_id(self, build_type_id,
+    @GET('builds/'
+         '?locator=buildType:{build_type_id},branch:{branch}'
+         '&start={start}&count={count}')
+    def get_all_builds_by_build_type_id(self, build_type_id, branch='',
                                         start=0, count=100):
         """
         Gets all builds of a build type build type id `btId`.

--- a/test_pyteamcity.py
+++ b/test_pyteamcity.py
@@ -125,37 +125,111 @@ def test_get_all_plugins():
     assert req.url == expected_url
 
 
-def test_get_all_builds():
+def test_get_builds_no_args():
     expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
-                    'builds/?start=0&count=100')
-    url = tc.get_all_builds(return_type='url')
+                    'builds/'
+                    '?locator=branch:'
+                    '&start=0&count=100')
+    url = tc.get_builds(return_type='url')
     assert url == expected_url
 
-    req = tc.get_all_builds(return_type='request')
+    req = tc.get_builds(return_type='request')
     assert req.method == 'GET'
     assert req.url == expected_url
 
 
-def test_get_all_builds_with_start_and_count():
+def test_get_builds_with_branch():
     expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
-                    'builds/?start=0&count=3')
-    url = tc.get_all_builds(start=0, count=3, return_type='url')
+                    'builds/'
+                    '?locator=branch:master'
+                    '&start=0&count=100')
+    url = tc.get_builds(branch='master', return_type='url')
     assert url == expected_url
 
-    req = tc.get_all_builds(start=0, count=3, return_type='request')
+    req = tc.get_builds(branch='master', return_type='request')
     assert req.method == 'GET'
     assert req.url == expected_url
 
 
-def test_get_all_builds_by_build_type_id():
+def test_get_builds_with_start_and_count():
     expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
-                    'buildTypes/id:package/builds/?start=0&count=3')
-    url = tc.get_all_builds_by_build_type_id(
-        build_type_id='package', start=0, count=3, return_type='url')
+                    'builds/'
+                    '?locator=branch:'
+                    '&start=0&count=3')
+    url = tc.get_builds(start=0, count=3, return_type='url')
     assert url == expected_url
 
-    req = tc.get_all_builds_by_build_type_id(
-        build_type_id='package', start=0, count=3, return_type='request')
+    req = tc.get_builds(start=0, count=3, return_type='request')
+    assert req.method == 'GET'
+    assert req.url == expected_url
+
+
+def test_get_builds_with_start_and_count_and_branch():
+    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+                    'builds/'
+                    '?locator=branch:master'
+                    '&start=0&count=3')
+    url = tc.get_builds(branch='master', start=0, count=3,
+                        return_type='url')
+    assert url == expected_url
+
+    req = tc.get_builds(branch='master', start=0, count=3,
+                        return_type='request')
+    assert req.method == 'GET'
+    assert req.url == expected_url
+
+
+def test_get_builds_by_build_type():
+    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+                    'builds/'
+                    '?locator=buildType:package,branch:'
+                    '&start=0&count=100')
+    url = tc.get_builds(
+        build_type_id='package',
+        return_type='url')
+    assert url == expected_url
+
+    req = tc.get_builds(
+        build_type_id='package',
+        return_type='request')
+    assert req.method == 'GET'
+    assert req.url == expected_url
+
+
+def test_get_builds_by_build_type_and_branch_and_start_and_count():
+    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+                    'builds/'
+                    '?locator=buildType:package,branch:master'
+                    '&start=0&count=3')
+    url = tc.get_builds(
+        build_type_id='package', branch='master',
+        start=0, count=3,
+        return_type='url')
+    assert url == expected_url
+
+    req = tc.get_builds(
+        build_type_id='package', branch='master',
+        start=0, count=3,
+        return_type='request')
+    assert req.method == 'GET'
+    assert req.url == expected_url
+
+
+def test_get_builds_by_build_type_and_start_and_count():
+    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+                    'builds/'
+                    '?locator=buildType:package,branch:'
+                    '&start=0&count=3')
+    url = tc.get_builds(
+        build_type_id='package',
+        start=0, count=3,
+        return_type='url')
+    assert url == expected_url
+
+    req = tc.get_builds(
+        build_type_id='package',
+        start=0, count=3,
+        return_type='request')
     assert req.method == 'GET'
     assert req.url == expected_url
 


### PR DESCRIPTION
Add `get_builds`: filter by `build_type` or `branch`

This is a smart wrapper for the existing `get_all_builds` and `get_all_builds_by_build_type_id` methods.

```python
    def get_builds(self, build_type_id='', branch='',
                   start=0, count=100, **kwargs):
```

Cc: @aconrad, @sudarkoff 