### PR TITLE
tox.ini: Measure coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,5 @@ envlist = py26, py27, pypy, py32, py33, py34, pypy3
 [testenv]
 deps =
     pytest
-commands = py.test {posargs:-v}
+    pytest-cov
+commands = py.test {posargs:-v --cov=pyteamcity --cov-report=term-missing}


### PR DESCRIPTION
```
$ tox -e py27
...
--------------------------------------------------------------- coverage: platform darwin, python 2.7.9-final-0 ----------------------------------------------------------------
Name         Stmts   Miss  Cover   Missing
------------------------------------------
pyteamcity      84     11    87%   54-58, 78-81, 91-92
```