### PR TITLE
test_get_builds_no_args_mock_send

### DIFF
--- a/test_pyteamcity.py
+++ b/test_pyteamcity.py
@@ -1,3 +1,7 @@
+import json
+import mock
+import requests
+
 from pyteamcity import TeamCity
 
 user = 'TEAMCITY_USER'
@@ -123,6 +127,39 @@ def test_get_all_plugins():
     req = tc.get_all_plugins(return_type='request')
     assert req.method == 'GET'
     assert req.url == expected_url
+
+
+def make_response(status_code, data):
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = json.dumps(data).encode('utf-8')
+    return response
+
+
+def test_get_builds_no_args_mock_send():
+    with mock.patch.object(tc.session, 'send') as mock_send:
+        expected_data = {
+            "count": 1,
+            "href": "/httpAuth/app/rest/builds/"
+                    "?locator=branch:&start=0&count=100",
+            'build': [
+                {
+                    "status": "FAILURE",
+                    "defaultBranch": True,
+                    "webUrl": "http://TEAMCITY_HOST:4567/viewLog.html"
+                              "?buildId=70322&buildTypeId=Ansvc_Branches_Py34",
+                    "number": "1",
+                    "state": "finished",
+                    "href": "/httpAuth/app/rest/builds/id:70322",
+                    "branchName": "develop",
+                    "buildTypeId": "Ansvc_Branches_Py34",
+                    "id": 70322,
+                },
+            ]
+        }
+        mock_send.return_value = make_response(200, expected_data)
+        data = tc.get_builds()
+        assert data == expected_data
 
 
 def test_get_builds_no_args():

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist = py26, py27, pypy, py32, py33, py34, pypy3
 
 [testenv]
 deps =
+    mock
     pytest
     pytest-cov
 commands = py.test {posargs:-v --cov=pyteamcity --cov-report=term-missing}


### PR DESCRIPTION
This increases test coverage by mocking `session.send` of `requests`, so we can more throughly test pyteamcity.

#### Before

```
Name         Stmts   Miss  Cover   Missing
------------------------------------------
pyteamcity      84     11    87%   54-58, 78-81, 91-92
```

#### After

```
Name         Stmts   Miss  Cover   Missing
------------------------------------------
pyteamcity      84      6    93%   57-58, 78-81
```