### PR TITLE
Add get_projects; replaces get_all_projects

### DIFF
--- a/pyteamcity.py
+++ b/pyteamcity.py
@@ -224,8 +224,18 @@ class TeamCity:
         :param build_type_id: the build type to get, in format bt[0-9]+
         """
 
+    def get_projects(self, parent_project_id=None, **kwargs):
+        return_type = kwargs.get('return_type')
+        all_projects_data = self._get_all_projects(**kwargs)
+
+        if parent_project_id is None or return_type in ('url', 'request'):
+            return all_projects_data
+
+        return [project for project in all_projects_data['project']
+                if parent_project_id == project.get('parentProjectId')]
+
     @GET('projects')
-    def get_all_projects(self):
+    def _get_all_projects(self):
         """
         Gets all projects in the TeamCity server pointed to by this instance of
         the Client.


### PR DESCRIPTION
```python
In [1]: from pyteamcity import TeamCity

In [2]: tc = TeamCity()

In [3]: tc.get_projects()
Out[3]:
{u'count': 188,
 u'href': u'/httpAuth/app/rest/projects',
 u'project': [{u'description': u'Contains all other projects',
   u'href': u'/httpAuth/app/rest/projects/id:_Root',
   u'id': u'_Root',
   u'name': u'<Root project>',
   u'webUrl': u'http://tcserver/project.html?projectId=_Root'},
  {u'href': u'/httpAuth/app/rest/projects/id:Admintools',
   u'id': u'Admintools',
   u'name': u'admintools',
   u'parentProjectId': u'_Root',
   u'webUrl': u'http://tcserver/project.html?projectId=Admintools'},
...

In [4]: tc.get_projects(parent_project_id='Admintools')
Out[4]:
[{u'href': u'/httpAuth/app/rest/projects/id:Admintools_Branches',
  u'id': u'Admintools_Branches',
  u'name': u'branches',
  u'parentProjectId': u'Admintools',
  u'webUrl': u'http://tcserver/project.html?projectId=Admintools_Branches'},
 {u'href': u'/httpAuth/app/rest/projects/id:Admintools_PullRequests',
  u'id': u'Admintools_PullRequests',
  u'name': u'pull requests',
  u'parentProjectId': u'Admintools',
  u'webUrl': u'http://tcserver/project.html?projectId=Admintools_PullRequests'},
...
```