### PR TITLE
get_projects: No change shape of data w/ parent_project_id

### DIFF
--- a/pyteamcity.py
+++ b/pyteamcity.py
@@ -231,8 +231,11 @@ class TeamCity:
         if parent_project_id is None or return_type in ('url', 'request'):
             return all_projects_data
 
-        return [project for project in all_projects_data['project']
-                if parent_project_id == project.get('parentProjectId')]
+        projects = [project for project in all_projects_data['project']
+                    if parent_project_id == project.get('parentProjectId')]
+        ret = {'count': len(projects),
+               'project': projects}
+        return ret
 
     @GET('projects')
     def _get_all_projects(self):

--- a/test_pyteamcity.py
+++ b/test_pyteamcity.py
@@ -146,7 +146,9 @@ def test_get_projects_parent_project_id_mock_send():
               'webUrl': 'http://tcserver/project.html?projectId=foo_child'},
             ]}
         mock_send.return_value = make_response(200, expected_data)
-        projects = tc.get_projects(parent_project_id='foo')
+        data = tc.get_projects(parent_project_id='foo')
+        assert data['count'] == 1
+        projects = data['project']
         assert len(projects) == 1
         project = projects[0]
         assert project['id'] == 'foo_child'


### PR DESCRIPTION
Before without filtering, we returned a dict with `count` and `project`
and when filtering we only returned the contents of `project` at the
top-level. That's awkward. Now when filtering, we also return a dict
with `count` and `project` to preserve the shape of the data.