### PR TITLE
Add HTTPS support

### DIFF
--- a/pyteamcity.py
+++ b/pyteamcity.py
@@ -115,21 +115,23 @@ class TeamCity:
     error_handler = None
 
     def __init__(self, username=None, password=None, server=None, port=None,
-                 session=None):
+                 session=None, protocol=None):
         self.username = username or os.getenv('TEAMCITY_USER')
         self.password = password or os.getenv('TEAMCITY_PASSWORD')
         self.host = server or os.getenv('TEAMCITY_HOST')
         self.port = port or int(os.getenv('TEAMCITY_PORT', 0)) or 80
-        self.base_base_url = "http://%s:%d" % (self.host, self.port)
-        self.guest_auth_base_url = "http://%s:%d/guestAuth" % (
-            self.host, self.port)
+        self.protocol = protocol or os.getenv('TEAMCITY_PROTOCOL')
+        self.base_base_url = "%s://%s:%d" % (
+            self.protocol, self.host, self.port)
+        self.guest_auth_base_url = "%s://%s:%d/guestAuth" % (
+            self.protocol, self.host, self.port)
         if self.username and self.password:
-            self.base_url = "http://%s:%d/httpAuth/app/rest" % (
-                self.host, self.port)
+            self.base_url = "%s://%s:%d/httpAuth/app/rest" % (
+                self.protocol, self.host, self.port)
             self.auth = (self.username, self.password)
         else:
-            self.base_url = "http://%s:%d/guestAuth/app/rest" % (
-                self.host, self.port)
+            self.base_url = "%s://%s:%d/guestAuth/app/rest" % (
+                self.protocol, self.host, self.port)
             self.auth = None
         self.session = session or requests.Session()
         self._agent_cache = {}

--- a/pyteamcity.py
+++ b/pyteamcity.py
@@ -120,7 +120,7 @@ class TeamCity:
         self.password = password or os.getenv('TEAMCITY_PASSWORD')
         self.host = server or os.getenv('TEAMCITY_HOST')
         self.port = port or int(os.getenv('TEAMCITY_PORT', 0)) or 80
-        self.protocol = protocol or os.getenv('TEAMCITY_PROTOCOL')
+        self.protocol = protocol or os.getenv('TEAMCITY_PROTOCOL', 'http')
         self.base_base_url = "%s://%s:%d" % (
             self.protocol, self.host, self.port)
         self.guest_auth_base_url = "%s://%s:%d/guestAuth" % (


### PR DESCRIPTION
I've added a protocol parameter to support HTTPS enabled TeamCity servers.
It could be configured by explicitly passing in `protocol` when initializing the class, or using the `TEAMCITY_PROTOCOL` environment variable.