### PR TITLE
fixed problem where non-json content type is coerced into json 

### DIFF
--- a/pyteamcity.py
+++ b/pyteamcity.py
@@ -92,7 +92,10 @@ def endpoint(url_pattern, method='GET'):
                                 url=url,
                                 status_code=response.status_code)
             try:
-                return response.json()
+                if response.headers['Content-Type'] == 'application/json':
+                    return response.json()
+                else:
+                    return response.content
             except Exception as e:
                 return response.text
         return inner_func


### PR DESCRIPTION
was trying to download a zip file, came back as a utf8 string while using get_build_artificacts_by_build_id() . This fix should return the raw content when the content-type is not 'application/json'