### PR TITLE
Adding API to get individual test history

### DIFF
--- a/pyteamcity.py
+++ b/pyteamcity.py
@@ -569,3 +569,11 @@ class TeamCity:
 
         :param username: the username to get details for.
         """
+
+    @GET('testOccurrences?locator=test:{test_locator}')
+    def get_test(self, test_locator):
+        """
+        Gets individual test history
+
+        :param test_locator: test id
+        """

--- a/test_pyteamcity.py
+++ b/test_pyteamcity.py
@@ -570,3 +570,17 @@ def test_get_build_type_kwarg():
         build_type_id='foo_build', return_type='request')
     assert req.method == 'GET'
     assert req.url == expected_url
+
+
+def test_get_test():
+    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+                    'testOccurrences?locator=test:12345')
+
+    url = tc.get_test(
+        test_locator='12345', return_type='url')
+    assert url == expected_url
+
+    req = tc.get_test(
+        test_locator='12345', return_type='request')
+    assert req.method == 'GET'
+    assert req.url == expected_url


### PR DESCRIPTION
https://confluence.jetbrains.com/display/TCD10/REST+API#RESTAPI-Tests

Get individual test history:
GET http://teamcity:8111/app/rest/testOccurrences?locator=test:<test locator>