### PR TITLE
tox.ini: Remove py32

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, pypy, py32, py33, py34, pypy3
+envlist = py26, py27, pypy, py33, py34, pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
It's hard to get modern tools to work with py32, so let's forget about it.