### PR TITLE
README.md: Switch PyPI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyTeamCity
 
-[![Latest Version](https://pypip.in/version/pyteamcity/badge.svg)](https://pypi.python.org/pypi/pyteamcity/)
+[![Latest Version](https://badge.fury.io/py/pyteamcity.svg)](https://pypi.python.org/pypi/pyteamcity/)
 [![Build Status](https://travis-ci.org/SurveyMonkey/pyteamcity.svg?branch=master)](https://travis-ci.org/SurveyMonkey/pyteamcity)
 
 Python interface to the [REST


### PR DESCRIPTION
from pypip.in to fury.io

https://github.com/SurveyMonkey/pyteamcity/tree/README_fury_io_pypi_badge