### PR TITLE
Fix flake8

### DIFF
--- a/pyteamcity/future/build_type.py
+++ b/pyteamcity/future/build_type.py
@@ -1,4 +1,3 @@
-from . import exceptions
 from .core.parameter import Parameter
 from .core.queryset import QuerySet
 from .core.utils import raise_on_status

--- a/pyteamcity/future/project.py
+++ b/pyteamcity/future/project.py
@@ -1,4 +1,3 @@
-from . import exceptions
 from .build_type import BuildType
 from .core.parameter import Parameter
 from .core.queryset import QuerySet

--- a/pyteamcity/future/queued_build.py
+++ b/pyteamcity/future/queued_build.py
@@ -1,4 +1,3 @@
-from . import exceptions
 from .core.parameter import Parameter
 from .core.queryset import QuerySet
 from .core.utils import parse_date_string, raise_on_status

--- a/pyteamcity/future/teamcity.py
+++ b/pyteamcity/future/teamcity.py
@@ -2,7 +2,6 @@ import os
 
 import requests
 
-from . import exceptions
 from .core.manager import Manager
 from .core.utils import parse_date_string, raise_on_status
 

--- a/pyteamcity/future/vcs_root.py
+++ b/pyteamcity/future/vcs_root.py
@@ -1,4 +1,3 @@
-from . import exceptions
 from .core.parameter import Parameter
 from .core.queryset import QuerySet
 from .core.utils import raise_on_status

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,6 @@ commands = py.test
 deps =
     flake8
 commands = flake8 {posargs:pyteamcity/future}
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
```
$ tox -e flake8
GLOB sdist-make: /Users/marca/dev/git-repos/pyteamcity/setup.py
flake8 inst-nodeps: /Users/marca/dev/git-repos/pyteamcity/.tox/dist/pyteamcity-0.1.1.zip
flake8 installed: You are using pip version 8.1.2, however version 9.0.1 is available.,You should consider upgrading via the 'pip install --upgrade pip' command.,beautifulsoup4==4.5.1,configparser==3.5.0,enum34==1.1.6,flake8==3.0.3,mccabe==0.5.2,pycodestyle==2.0.0,pyflakes==1.2.3,pyteamcity==0.1.1,python-dateutil=0
flake8 runtests: PYTHONHASHSEED='3728627254'
flake8 runtests: commands[0] | flake8 pyteamcity/future
_________________________________________________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________________________________________________
  flake8: commands succeeded
  congratulations :)
```