### PR TITLE
fix legacy tests to work with requests>=2.12.4

### DIFF
--- a/pyteamcity/legacy/test_legacy.py
+++ b/pyteamcity/legacy/test_legacy.py
@@ -8,14 +8,14 @@ from pyteamcity import TeamCity, HTTPError
 
 user = 'TEAMCITY_USER'
 password = 'TEAMCITY_PASSWORD'
-host = 'TEAMCITY_HOST'
+host = 'teamcity_host'
 port = 4567
 
 tc = TeamCity(user, password, host, port)
 
 
 def test_get_all_users():
-    expected_url = 'http://TEAMCITY_HOST:4567/httpAuth/app/rest/users'
+    expected_url = 'http://teamcity_host:4567/httpAuth/app/rest/users'
     url = tc.get_all_users(return_type='url')
     assert url == expected_url
 
@@ -25,7 +25,7 @@ def test_get_all_users():
 
 
 def test_get_user_by_username():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'users/username:codyw')
     url = tc.get_user_by_username('codyw', return_type='url')
     assert url == expected_url
@@ -36,7 +36,7 @@ def test_get_user_by_username():
 
 
 def test_get_all_vcs_roots():
-    expected_url = 'http://TEAMCITY_HOST:4567/httpAuth/app/rest/vcs-roots'
+    expected_url = 'http://teamcity_host:4567/httpAuth/app/rest/vcs-roots'
     url = tc.get_all_vcs_roots(return_type='url')
     assert url == expected_url
 
@@ -46,7 +46,7 @@ def test_get_all_vcs_roots():
 
 
 def test_get_vcs_root_by_vcs_root_id():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'vcs-roots/id:41')
     url = tc.get_vcs_root_by_vcs_root_id(41, return_type='url')
     assert url == expected_url
@@ -57,7 +57,7 @@ def test_get_vcs_root_by_vcs_root_id():
 
 
 def test_get_agents():
-    expected_url = 'http://TEAMCITY_HOST:4567/httpAuth/app/rest/agents'
+    expected_url = 'http://teamcity_host:4567/httpAuth/app/rest/agents'
     url = tc.get_agents(return_type='url')
     assert url == expected_url
 
@@ -67,7 +67,7 @@ def test_get_agents():
 
 
 def test_get_agent_by_agent_id():
-    expected_url = 'http://TEAMCITY_HOST:4567/httpAuth/app/rest/agents/id:41'
+    expected_url = 'http://teamcity_host:4567/httpAuth/app/rest/agents/id:41'
     url = tc.get_agent_by_agent_id(41, return_type='url')
     assert url == expected_url
 
@@ -77,7 +77,7 @@ def test_get_agent_by_agent_id():
 
 
 def test_get_agent_by_agent_name():
-    expected_url = 'http://TEAMCITY_HOST:4567/httpAuth/app/rest/agents/name:test'
+    expected_url = 'http://teamcity_host:4567/httpAuth/app/rest/agents/name:test'
     url = tc.get_agent_by_agent_name('test', return_type='url')
     assert url == expected_url
 
@@ -87,7 +87,7 @@ def test_get_agent_by_agent_name():
 
 
 def test_get_projects():
-    expected_url = 'http://TEAMCITY_HOST:4567/httpAuth/app/rest/projects'
+    expected_url = 'http://teamcity_host:4567/httpAuth/app/rest/projects'
     url = tc.get_projects(return_type='url')
     assert url == expected_url
 
@@ -97,7 +97,7 @@ def test_get_projects():
 
 
 def test_get_projects_parent_project_id():
-    expected_url = 'http://TEAMCITY_HOST:4567/httpAuth/app/rest/projects'
+    expected_url = 'http://teamcity_host:4567/httpAuth/app/rest/projects'
     url = tc.get_projects(parent_project_id='foo', return_type='url')
     assert url == expected_url
 
@@ -167,7 +167,7 @@ def test_get_projects_parent_project_id_mock_send():
 
 
 def test_get_project_by_project_id_arg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest'
                     '/projects/id:foo_project')
     url = tc.get_project_by_project_id('foo_project', return_type='url')
     assert url == expected_url
@@ -178,7 +178,7 @@ def test_get_project_by_project_id_arg():
 
 
 def test_get_project_by_project_id_kwarg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'projects/id:foo_project')
     url = tc.get_project_by_project_id(
         project_id='foo_project', return_type='url')
@@ -191,7 +191,7 @@ def test_get_project_by_project_id_kwarg():
 
 
 def test_get_server_info():
-    expected_url = 'http://TEAMCITY_HOST:4567/httpAuth/app/rest/server'
+    expected_url = 'http://teamcity_host:4567/httpAuth/app/rest/server'
     url = tc.get_server_info(return_type='url')
     assert url == expected_url
 
@@ -201,7 +201,7 @@ def test_get_server_info():
 
 
 def test_get_all_plugins():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'server/plugins')
     url = tc.get_all_plugins(return_type='url')
     assert url == expected_url
@@ -229,7 +229,7 @@ def test_get_builds_mock_send():
                 {
                     "status": "FAILURE",
                     "defaultBranch": True,
-                    "webUrl": "http://TEAMCITY_HOST:4567/viewLog.html"
+                    "webUrl": "http://teamcity_host:4567/viewLog.html"
                               "?buildId=70322&buildTypeId=Ansvc_Branches_Py34",
                     "number": "1",
                     "state": "finished",
@@ -257,7 +257,7 @@ def test_get_builds_mock_send_simulate_error():
 
 
 def test_get_builds_no_args():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?start=0&count=100')
     url = tc.get_builds(return_type='url')
@@ -269,7 +269,7 @@ def test_get_builds_no_args():
 
 
 def test_get_builds_with_branch():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=branch:master'
                     '&start=0&count=100')
@@ -282,7 +282,7 @@ def test_get_builds_with_branch():
 
 
 def test_get_builds_with_start_and_count():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?start=0&count=3')
     url = tc.get_builds(start=0, count=3, return_type='url')
@@ -294,7 +294,7 @@ def test_get_builds_with_start_and_count():
 
 
 def test_get_builds_with_start_and_count_and_branch():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=branch:master'
                     '&start=0&count=3')
@@ -309,7 +309,7 @@ def test_get_builds_with_start_and_count_and_branch():
 
 
 def test_get_builds_by_build_type():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=buildType:package'
                     '&start=0&count=100')
@@ -326,7 +326,7 @@ def test_get_builds_by_build_type():
 
 
 def test_get_builds_by_build_type_and_branch_and_start_and_count():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=branch:master,buildType:package'
                     '&start=0&count=3')
@@ -345,7 +345,7 @@ def test_get_builds_by_build_type_and_branch_and_start_and_count():
 
 
 def test_get_builds_by_build_type_and_branch_and_status_start_and_count():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=branch:master,buildType:package,status:failure'
                     '&start=0&count=3')
@@ -364,7 +364,7 @@ def test_get_builds_by_build_type_and_branch_and_status_start_and_count():
 
 
 def test_get_builds_by_build_type_and_branch_and_tags_start_and_count():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=branch:master,buildType:package,tags:jobsvc'
                     '&start=0&count=3')
@@ -383,7 +383,7 @@ def test_get_builds_by_build_type_and_branch_and_tags_start_and_count():
 
 
 def test_get_builds_by_build_type_and_branch_and_user_start_and_count():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=branch:master,buildType:package,user:johna'
                     '&start=0&count=3')
@@ -402,7 +402,7 @@ def test_get_builds_by_build_type_and_branch_and_user_start_and_count():
 
 
 def test_get_builds_by_build_type_and_start_and_count():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=buildType:package'
                     '&start=0&count=3')
@@ -420,7 +420,7 @@ def test_get_builds_by_build_type_and_start_and_count():
     assert req.url == expected_url
 
 def test_get_builds_by_since_build():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=sinceBuild:sinceTestBuild'
                     '&start=0&count=100')
@@ -436,7 +436,7 @@ def test_get_builds_by_since_build():
     assert req.url == expected_url
 
 def test_get_builds_by_until_build():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=untilBuild:untilTestBuild'
                     '&start=0&count=100')
@@ -452,7 +452,7 @@ def test_get_builds_by_until_build():
     assert req.url == expected_url
 
 def test_get_builds_by_since_date():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=sinceDate:sinceTestDate'
                     '&start=0&count=100')
@@ -469,7 +469,7 @@ def test_get_builds_by_since_date():
 
 
 def test_get_builds_by_until_date():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=untilDate:untilTestDate'
                     '&start=0&count=100')
@@ -486,7 +486,7 @@ def test_get_builds_by_until_date():
 
 
 def test_get_builds_by_pinned():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'builds/'
                     '?locator=pinned:True'
                     '&start=0&count=100')
@@ -503,7 +503,7 @@ def test_get_builds_by_pinned():
 
 
 def test_get_build_by_build_id_arg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest'
                     '/builds/id:foo_build')
     url = tc.get_build_by_build_id('foo_build', return_type='url')
     assert url == expected_url
@@ -514,7 +514,7 @@ def test_get_build_by_build_id_arg():
 
 
 def test_get_build_by_build_id_kwarg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest'
                     '/builds/id:foo_build')
     url = tc.get_build_by_build_id(
         build_id='foo_build', return_type='url')
@@ -527,7 +527,7 @@ def test_get_build_by_build_id_kwarg():
 
 
 def test_get_build_statistics_by_build_statistics_id_arg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest'
                     '/builds/id:foo_build/statistics')
     url = tc.get_build_statistics_by_build_id(
         'foo_build', return_type='url')
@@ -540,7 +540,7 @@ def test_get_build_statistics_by_build_statistics_id_arg():
 
 
 def test_get_build_statistics_by_build_id_kwarg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest'
                     '/builds/id:foo_build/statistics')
     url = tc.get_build_statistics_by_build_id(
         build_id='foo_build', return_type='url')
@@ -553,7 +553,7 @@ def test_get_build_statistics_by_build_id_kwarg():
 
 
 def test_get_build_tags_by_build_tags_id_arg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest'
                     '/builds/id:foo_build/tags')
     url = tc.get_build_tags_by_build_id('foo_build', return_type='url')
     assert url == expected_url
@@ -564,7 +564,7 @@ def test_get_build_tags_by_build_tags_id_arg():
 
 
 def test_get_build_tags_by_build_id_kwarg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest'
                     '/builds/id:foo_build/tags')
     url = tc.get_build_tags_by_build_id(
         build_id='foo_build', return_type='url')
@@ -577,7 +577,7 @@ def test_get_build_tags_by_build_id_kwarg():
 
 
 def test_get_all_changes():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'changes?start=0&count=10')
     url = tc.get_all_changes(return_type='url')
     assert url == expected_url
@@ -588,7 +588,7 @@ def test_get_all_changes():
 
 
 def test_get_change_by_change_id_arg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'changes/id:16884')
     url = tc.get_change_by_change_id(16884, return_type='url')
     assert url == expected_url
@@ -599,7 +599,7 @@ def test_get_change_by_change_id_arg():
 
 
 def test_get_change_by_change_id_kwarg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'changes/id:16884')
     url = tc.get_change_by_change_id(change_id=16884, return_type='url')
     assert url == expected_url
@@ -610,7 +610,7 @@ def test_get_change_by_change_id_kwarg():
 
 
 def test_get_changes_by_build_id_arg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'changes/build:id:73450')
     url = tc.get_changes_by_build_id(73450, return_type='url')
     assert url == expected_url
@@ -621,7 +621,7 @@ def test_get_changes_by_build_id_arg():
 
 
 def test_get_changes_by_build_id_kwarg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'changes/build:id:73450')
     url = tc.get_changes_by_build_id(build_id=73450, return_type='url')
     assert url == expected_url
@@ -632,7 +632,7 @@ def test_get_changes_by_build_id_kwarg():
 
 
 def test_get_build_types():
-    expected_url = 'http://TEAMCITY_HOST:4567/httpAuth/app/rest/buildTypes/'
+    expected_url = 'http://teamcity_host:4567/httpAuth/app/rest/buildTypes/'
     url = tc.get_build_types(return_type='url')
     assert url == expected_url
 
@@ -642,7 +642,7 @@ def test_get_build_types():
 
 
 def test_get_build_type_arg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'buildTypes/id:foo_build')
     url = tc.get_build_type('foo_build', return_type='url')
     assert url == expected_url
@@ -653,7 +653,7 @@ def test_get_build_type_arg():
 
 
 def test_get_build_type_kwarg():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'buildTypes/id:foo_build')
     url = tc.get_build_type(
         build_type_id='foo_build', return_type='url')
@@ -666,7 +666,7 @@ def test_get_build_type_kwarg():
 
 
 def test_get_test():
-    expected_url = ('http://TEAMCITY_HOST:4567/httpAuth/app/rest/'
+    expected_url = ('http://teamcity_host:4567/httpAuth/app/rest/'
                     'testOccurrences?locator=test:12345')
 
     url = tc.get_test(


### PR DESCRIPTION
It seems that the internals of the requests library changed a few
times and broke different things after requests==2.11.1 which is
the version when the tests passed last. Then versions of requests
2.12.0, 2.12.1, 2.12.2, 2.12.3 all broke the tests and finally
version 2.12.4 worked but for the tests to pass we need the changes
from this commit.