### PR TITLE
Add pyteamcity.future to packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     maintainer_email='marc@marc-abramowitz.com',
     author='Yotam Oron',
     author_email='yotamoron@yahoo.com',
-    packages=['pyteamcity', 'pyteamcity.legacy'],
+    packages=['pyteamcity', 'pyteamcity.legacy', 'pyteamcity.future'],
     zip_safe=False,
     install_requires=[
         'beautifulsoup4',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from setuptools import setup
+from setuptools import setup, find_packages
 
 version = '0.1.1'
 
@@ -25,7 +25,7 @@ setup(
     maintainer_email='marc@marc-abramowitz.com',
     author='Yotam Oron',
     author_email='yotamoron@yahoo.com',
-    packages=['pyteamcity', 'pyteamcity.legacy', 'pyteamcity.future', 'pyteamcity.future.core'],
+    packages=find_packages(),
     zip_safe=False,
     install_requires=[
         'beautifulsoup4',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     maintainer_email='marc@marc-abramowitz.com',
     author='Yotam Oron',
     author_email='yotamoron@yahoo.com',
-    packages=['pyteamcity', 'pyteamcity.legacy', 'pyteamcity.future'],
+    packages=['pyteamcity', 'pyteamcity.legacy', 'pyteamcity.future', 'pyteamcity.future.core'],
     zip_safe=False,
     install_requires=[
         'beautifulsoup4',


### PR DESCRIPTION
This is so that we can install and use `pyteamcity.future` using pip:

```
pip install -e git+https://github.com/SurveyMonkey/pyteamcity#egg=pyteamcity
```

while waiting for the new API to be officially released (#70)