### PR TITLE
Added support for change details.

### DIFF
--- a/pyteamcity/future/change_details.py
+++ b/pyteamcity/future/change_details.py
@@ -1,0 +1,26 @@
+from . import exceptions
+from .core.utils import raise_on_status
+
+
+class ChangeDetails(object):
+    def __init__(self, change):
+        self.change = change
+        teamcity = self.change.change_query_set.teamcity
+        url = self.change.api_url
+        res = teamcity.session.get(url)
+        if res.status_code == 404:
+            raise exceptions.ChangeDetailsNotFound(id=self.change.id)
+        raise_on_status(res)
+        self._data = res.json()
+        self._metadata_url = url
+
+    @property
+    def comment(self):
+        return self._data['comment']
+
+    def __repr__(self):
+        return '<%s.%s: change.id=%r comment=%r>' % (
+            self.__module__,
+            self.__class__.__name__,
+            self.change.id,
+            self.comment)

--- a/pyteamcity/future/core/queryset.py
+++ b/pyteamcity/future/core/queryset.py
@@ -72,10 +72,10 @@ class QuerySet(object):
             raise exceptions.MultipleObjectsReturned()
         self._data_dict = None
         if just_url:
-            return self._get_url(details=True)
+            return self._get_url(details=False)
         else:
             return self.__class__._from_dict(
-                self._data(details=True), self)
+                self._data(details=False), self)
 
     def __len__(self):
         data = self._data()

--- a/pyteamcity/future/exceptions.py
+++ b/pyteamcity/future/exceptions.py
@@ -26,6 +26,14 @@ class ArtifactNotFound(Error):
         return 'Artifact not found: %s' % self.path
 
 
+class ChangeDetailsNotFound(Error):
+    def __init__(self, id):
+        self.iud = id
+
+    def __str__(self):
+        return 'Change details not found: %s' % self.id
+
+
 class HTTPError(Error):
     def __init__(self, status_code, reason, text):
         self.status_code = status_code


### PR DESCRIPTION
Change details such as comment and changed files requires a secondary query.
This pull request only supports the "comment" field, but it should be trivial to expand it to cover files and VCS root.
No unit tests written. I did not have my environment set up for running Python unit tests.