### PR TITLE
Fix broken coverage reports

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     pytest
     pytest-cov
     responses
+    coverage>=4.0,<4.4
 passenv =
     TEAMCITY_HOST
     TEAMCITY_USER


### PR DESCRIPTION
See https://bitbucket.org/ned/coveragepy/issues/578/incomplete-file-path-in-xml-report