### PR TITLE
Made get_changes_by_build_id return list of changes

### DIFF
--- a/pyteamcity/legacy/legacy.py
+++ b/pyteamcity/legacy/legacy.py
@@ -296,7 +296,7 @@ class TeamCity:
         :param change_id: the change to get, in the format [0-9]+
         """
 
-    @GET('changes/build:id:{build_id}')
+    @GET('changes?locator=build:{build_id}')
     def get_changes_by_build_id(self, build_id):
         """
         Gets changes in a build for a build ID `build_id`.


### PR DESCRIPTION
get_changes_by_build_id(int) returns only vcs root change of a build, but must (in my opion) return list of changes in a build